### PR TITLE
Keep current officer sources authoritative

### DIFF
--- a/lib/chatSources.js
+++ b/lib/chatSources.js
@@ -25,10 +25,11 @@ export function getContextSourceLabels(
   question,
   { hasEvents = false, knowledgeSources = [] } = {}
 ) {
-  const labels = [];
   if (isCurrentLeadershipQuestion(question)) {
-    labels.push("Current leadership roster");
+    return ["Current leadership roster"];
   }
+
+  const labels = [];
   if (hasEvents && isUpcomingEventQuestion(question)) {
     labels.push("Upcoming events");
   }

--- a/tests/chatSources.test.mjs
+++ b/tests/chatSources.test.mjs
@@ -35,6 +35,6 @@ test("labels are relevant, unique, and bounded", () => {
       hasEvents: true,
       knowledgeSources: ["Leadership policy"],
     }),
-    ["Current leadership roster", "Leadership policy"]
+    ["Current leadership roster"]
   );
 });


### PR DESCRIPTION
## Summary

- Shows only the current leadership roster label for current-officeholder answers.
- Prevents historical constitution rows from appearing as current officer sources.

## Validation

- 16 Node tests
- Lint
- Next production build
- Live smoke test identified and reproduced the issue