### PR TITLE
Footer address left

### DIFF
--- a/components/footer.jsx
+++ b/components/footer.jsx
@@ -14,24 +14,24 @@ const Footer = () => {
       </div>
       <div className="flex flex-col sm:flex-row items-center w-full sm:w-auto">
         <div className="flex items-center">
-          <div className="flex flex-col sm:flex-row items-center ml-0 sm:ml-5 mt-5 sm:mt-0">
-            <a href="https://www.linkedin.com/company/ktputd" target="_blank" rel="noopener noreferrer" aria-label="KTP on LinkedIn">
-              <FaLinkedin className="mr-0 sm:mr-[2px] text-[#ffffff] transition-transform duration-300 hover:scale-125" size={40} />
-            </a>
-            <a href="https://www.instagram.com/utdktp/" target="_blank" rel="noopener noreferrer" className="sm:ml-5" aria-label="KTP on Instagram">
-              <FaInstagram className="mr-0 sm:mr-[2px] text-[#ffffff] transition-transform duration-300 hover:scale-125" size={40} />
-            </a>
-            <a href="mailto:president@utdktp.com" className="sm:ml-5" aria-label="Email KTP">
-              <FaEnvelope className="mr-0 sm:mr-[2px] text-[#ffffff] transition-transform duration-300 hover:scale-125" size={40} />
-            </a>
-            <span className="sm:ml-5 text-gray-300 font-poppins text-sm">
-              800 W. Campbell Road, Richardson, Texas 75080-3021
-            </span>
-            <a href="https://github.com/KappaThetaPiUTD" target="_blank" rel="noopener noreferrer" className="sm:ml-5" aria-label="KTP on GitHub">
-              <FaGithub className="mr-0 sm:mr-[2px] text-[#ffffff] transition-transform duration-300 hover:scale-125" size={40} />
-            </a>
-          </div>
+          <a href="https://www.linkedin.com/company/ktputd" target="_blank" rel="noopener noreferrer" aria-label="KTP on LinkedIn">
+            <FaLinkedin className="mr-0 sm:mr-[2px] text-[#ffffff] transition-transform duration-300 hover:scale-125" size={40} />
+          </a>
+          <a href="https://www.instagram.com/utdktp/" target="_blank" rel="noopener noreferrer" className="sm:ml-5" aria-label="KTP on Instagram">
+            <FaInstagram className="mr-0 sm:mr-[2px] text-[#ffffff] transition-transform duration-300 hover:scale-125" size={40} />
+          </a>
+          <a href="mailto:president@utdktp.com" className="sm:ml-5" aria-label="Email KTP">
+            <FaEnvelope className="mr-0 sm:mr-[2px] text-[#ffffff] transition-transform duration-300 hover:scale-125" size={40} />
+          </a>
+          <a href="https://github.com/KappaThetaPiUTD" target="_blank" rel="noopener noreferrer" className="sm:ml-5" aria-label="KTP on GitHub">
+            <FaGithub className="mr-0 sm:mr-[2px] text-[#ffffff] transition-transform duration-300 hover:scale-125" size={40} />
+          </a>
         </div>
+      </div>
+      <div className="sm:mt-4 text-center">
+        <span className="text-gray-300 font-poppins text-sm">
+          800 W. Campbell Road, Richardson, Texas 75080-3021
+        </span>
       </div>
       
     </footer>

--- a/components/footer.jsx
+++ b/components/footer.jsx
@@ -4,10 +4,10 @@ import MailIcon from "./mail-icon-footer";
 const Footer = () => {
   return (
     <footer className="flex flex-col sm:flex-row justify-between items-center bottom-0 w-full z-10 bg-primary text-[#ffffff] p-5 font-poppins">
-    <div className="text-center sm:text-right mt-5 sm:mt-0">
-      <div className="text-left sm:text-left mt-5 sm:mt-0">
-            The University of Texas at Dallas
-          </div>
+      <div className="text-left mt-5 sm:mt-0">
+        <div>
+          The University of Texas at Dallas
+        </div>
         <div className="text-[20px] sm:text-[25px] font-bold mb-1 font-poppins">
           Kappa Theta Pi - Mu Chapter
         </div>
@@ -15,24 +15,20 @@ const Footer = () => {
           800 W. Campbell Road, Richardson, Texas 75080-3021
         </div>
       </div>
-      <div className="flex flex-col sm:flex-row items-center w-full sm:w-auto">
-        <div className="flex items-center">
-          <a href="https://www.linkedin.com/company/ktputd" target="_blank" rel="noopener noreferrer" aria-label="KTP on LinkedIn">
-            <FaLinkedin className="mr-0 sm:mr-[2px] text-[#ffffff] transition-transform duration-300 hover:scale-125" size={40} />
-          </a>
-          <a href="https://www.instagram.com/utdktp/" target="_blank" rel="noopener noreferrer" className="sm:ml-5" aria-label="KTP on Instagram">
-            <FaInstagram className="mr-0 sm:mr-[2px] text-[#ffffff] transition-transform duration-300 hover:scale-125" size={40} />
-          </a>
-          <a href="mailto:president@utdktp.com" className="sm:ml-5" aria-label="Email KTP">
-            <FaEnvelope className="mr-0 sm:mr-[2px] text-[#ffffff] transition-transform duration-300 hover:scale-125" size={40} />
-          </a>
-          <a href="https://github.com/KappaThetaPiUTD" target="_blank" rel="noopener noreferrer" className="sm:ml-5" aria-label="KTP on GitHub">
-            <FaGithub className="mr-0 sm:mr-[2px] text-[#ffffff] transition-transform duration-300 hover:scale-125" size={40} />
-          </a>
-        </div>
+      <div className="flex items-center mt-5 sm:mt-0">
+        <a href="https://www.linkedin.com/company/ktputd" target="_blank" rel="noopener noreferrer" aria-label="KTP on LinkedIn">
+          <FaLinkedin className="mr-0 sm:mr-[2px] text-[#ffffff] transition-transform duration-300 hover:scale-125" size={40} />
+        </a>
+        <a href="https://www.instagram.com/utdktp/" target="_blank" rel="noopener noreferrer" className="sm:ml-5" aria-label="KTP on Instagram">
+          <FaInstagram className="mr-0 sm:mr-[2px] text-[#ffffff] transition-transform duration-300 hover:scale-125" size={40} />
+        </a>
+        <a href="mailto:president@utdktp.com" className="sm:ml-5" aria-label="Email KTP">
+          <FaEnvelope className="mr-0 sm:mr-[2px] text-[#ffffff] transition-transform duration-300 hover:scale-125" size={40} />
+        </a>
+        <a href="https://github.com/KappaThetaPiUTD" target="_blank" rel="noopener noreferrer" className="sm:ml-5" aria-label="KTP on GitHub">
+          <FaGithub className="mr-0 sm:mr-[2px] text-[#ffffff] transition-transform duration-300 hover:scale-125" size={40} />
+        </a>
       </div>
-      
-      
     </footer>
   );
 };

--- a/components/footer.jsx
+++ b/components/footer.jsx
@@ -14,6 +14,9 @@ const Footer = () => {
         <div className="text-gray-300 font-poppins text-sm mt-1">
           800 W. Campbell Road, Richardson, Texas 75080-3021
         </div>
+        <div className="text-gray-300 font-poppins text-sm mt-1">
+          Charity ID: 33-1294470
+        </div>
       </div>
       <div className="flex items-center mt-5 sm:mt-0">
         <a href="https://www.linkedin.com/company/ktputd" target="_blank" rel="noopener noreferrer" aria-label="KTP on LinkedIn">

--- a/components/footer.jsx
+++ b/components/footer.jsx
@@ -11,6 +11,9 @@ const Footer = () => {
         <div className="text-[20px] sm:text-[25px] font-bold mb-1 font-poppins">
           Kappa Theta Pi - Mu Chapter
         </div>
+        <div className="text-gray-300 font-poppins text-sm mt-1">
+          800 W. Campbell Road, Richardson, Texas 75080-3021
+        </div>
       </div>
       <div className="flex flex-col sm:flex-row items-center w-full sm:w-auto">
         <div className="flex items-center">
@@ -28,11 +31,7 @@ const Footer = () => {
           </a>
         </div>
       </div>
-      <div className="sm:mt-4 text-center">
-        <span className="text-gray-300 font-poppins text-sm">
-          800 W. Campbell Road, Richardson, Texas 75080-3021
-        </span>
-      </div>
+      
       
     </footer>
   );


### PR DESCRIPTION
This PR adds the physical address and charity ID to the footer, and fixes the layout to:
- Move address under "Kappa Theta Pi - Mu Chapter" (not in the middle)
- Move icons to the right side (not in the middle)
- Left-align all text (UT Dallas, Kappa Theta Pi, address)
- Add Charity ID: 33-1294470